### PR TITLE
Moved 'use strict' declaration inside IIFE to avoid jshint warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,8 +67,8 @@ function angularModules(fileName, options)
 
         var result;
 
-        result = "'use strict';\n";
-        result += "(function (ng) {\n";
+        result = "(function (ng) {\n";
+        result += "'use strict';\n";
         result += "ng.module('"+ options.name +"', ['"+ list.join("','") +"']);\n";
         result += "})(angular);";
 

--- a/spec/all.spec.js
+++ b/spec/all.spec.js
@@ -24,8 +24,8 @@ describe('when using gulp-angular-modules', function() {
             // make sure it came out the same way it went in
             expect(file.isBuffer()).toBeTruthy();
 
-            var result = "'use strict';\n";
-            result += "(function (ng) {\n";
+            var result = "(function (ng) {\n";
+            result += "'use strict';\n";
             result += "ng.module('gulp-angular-modules', ['module.name','module.name2']);\n";
             result += "})(angular);";
 


### PR DESCRIPTION
I made a minor change to put 'use strict' inside the IIFE to avoid the "use function form of 'use strict'" warnings from jshint.
